### PR TITLE
Changed default values in FGame and removed a function

### DIFF
--- a/fgame.cpp
+++ b/fgame.cpp
@@ -2,10 +2,7 @@
 
 FGame::FGame()
 {
-    this->gameName = "Unknown";
-    this->gameExe = "Unknown";
-    this->gamePath = "Unknown";
-    this->gameArgs = "Unknown";
+
 }
 
 QString FGame::getName() {
@@ -22,15 +19,9 @@ QString FGame::getPath()
     return this->gamePath;
 }
 
-QString FGame::getArgs()
+QStringList FGame::getArgs()
 {
     return this->gameArgs;
-}
-
-QString FGame::getAbsPath()
-{
-    QString RawString = "%1/%2 %3";
-    return RawString.arg(this->getPath(), this->getExe(), this->getArgs());
 }
 
 void FGame::setName(QString val)
@@ -48,7 +39,7 @@ void FGame::setPath(QString val)
     this->gamePath = val;
 }
 
-void FGame::setArgs(QString val)
+void FGame::setArgs(QStringList val)
 {
     this->gameArgs = val;
 }

--- a/fgame.h
+++ b/fgame.h
@@ -12,17 +12,16 @@ public:
     QString getName();
     QString getExe();
     QString getPath();
-    QString getArgs();
-    QString getAbsPath();
+    QStringList getArgs();
     void setName(QString val);
     void setExe(QString val);
     void setPath(QString val);
-    void setArgs(QString val);
+    void setArgs(QStringList val);
 private:
     QString gameName;
     QString gameExe;
     QString gamePath;
-    QString gameArgs;
+    QStringList gameArgs;
 };
 
 #endif // FGAME_H


### PR DESCRIPTION
Removed the initialization of the gameName, gameExe, gamePath and gameArgs - what if the user wants to use "Unknown" as the name? (also, launching `Unknown/Unknown Unknown` might not be the best idea.)

Removed getAbsPath(), since it wasn't Windows friendly (would need to get the OS-specific directory separator, would possibly break on a string ending in a backslash). Should probably be implemented either somewhere else or here with a way of getting the separator.

Changed type of gameArgs to QStringList (since it's the type of arguments for QProcess)
