### PR TITLE
Moves game creation from query to separate function and fixes launch bug

### DIFF
--- a/fdb.h
+++ b/fdb.h
@@ -22,7 +22,7 @@ public:
     bool addGame(FGame game);
     bool removeGameById(int id);
     FGame* getGame(int id);
-    QList<FGame> getGameList();
+    QList<FGame *> getGameList();
     int getGameCount();
 
     QString getTextPref(QString pref);
@@ -62,6 +62,7 @@ private:
     QSqlDatabase db;
     QSqlQuery query;
 
+    FGame *createGameFromQuery(QSqlQuery query);
 signals:
 
 public slots:


### PR DESCRIPTION
Moves game creation into its own function and fixes a launch bug where
a game would think it had a launcher with id -1.

Needs to be merged together with the FusionClient PR.
